### PR TITLE
Decode poll options even when using quill composer

### DIFF
--- a/public/js/poll/serializer.js
+++ b/public/js/poll/serializer.js
@@ -13,7 +13,7 @@
 	}
 
 	var pollRegex = /(?:(?:\[poll(?<settings>.*?)\])(?:\\n|\n|<br \/>)(?<content>(?:-.+?(?:\\n|\n|<br \/>))+)(?:\[\/poll\]))/g;
-	var settingsRegex = /(?<key>.+?)=(?:"|&quot;)(?<value>.+?)(?:"|&quot;)/g;
+	var settingsRegex = /(?<key>.+?)=(?:"|&quot;|&#92;)(?<value>.+?)(?:"|&quot;|&#92;)/g;
 	var settingsValidators = {
 		title: {
 			test: function (value) {
@@ -132,7 +132,7 @@
 			settings[key] = config.defaults[key];
 		});
 
-		const stripped = utils.stripHTMLTags(raw);
+		const stripped = utils.stripHTMLTags(raw).replace(/\\/g, '&#92;');
 		let match;
 		while ((match = settingsRegex.exec(stripped)) !== null) {
 			var key = match.groups.key.trim();


### PR DESCRIPTION
When using quill composer, the raw data provided to the serializer looks like this for the settings: `" title=\\\"This is the poll title\\\" maxvotes=\\\"2\\\""` 
Because the `settingRegex` is not covering this markup, the options fail to be parsed so that the default options are used. I've updated here the settings regex and replace the escaped backslashes in the raw data.