### PR TITLE
Allow poll options to include hyphens

### DIFF
--- a/public/js/poll/serializer.js
+++ b/public/js/poll/serializer.js
@@ -85,7 +85,7 @@ module.exports = function (utils) {
 
 		rawOptions.forEach(function (option) {
 			if (option.length) {
-				option = option.split('-')[1].trim();
+				option = option.split('-').slice(1).join('-').trim()
 
 				if (option.length) {
 					pollOptions.push(option);


### PR DESCRIPTION
The fact that any hyphens in the body of a poll option will drop all text after the first, combined with the inability to edit the poll options after, can be disruptive.

This patch is very simplistic; my NodeBB admin has done basic testing to verify, but we don't know what the potential blast radius could be.