### PR TITLE
Fix issue #133

### DIFF
--- a/lib/poll.js
+++ b/lib/poll.js
@@ -132,6 +132,9 @@ const Scheduler = require('./scheduler');
 			if (err) {
 				return callback(err);
 			}
+			// sort options according to option id. option id are supposed to preseve the order as in Poll.add(),
+			// when the user create the poll
+			options.sort((a, b) => a - b);
 			async.map(options, (option, next) => {
 				Poll.getOption(pollId, option, withVotes, next);
 			}, callback);


### PR DESCRIPTION
This should fix wrong order of post items. We preserve the order as in `Poll.add()` when `pollData.options` get indexed by consecutive option id.