### PR TITLE
allow clicking outside the modal to close

### DIFF
--- a/public/js/poll/view.js
+++ b/public/js/poll/view.js
@@ -249,6 +249,7 @@
 		app.parseAndTranslate('poll/view/details', details, function (html) {
 			bootbox.dialog({
 				message: html,
+				backdrop: true,
 				buttons: {
 					close: {
 						label: 'Close',


### PR DESCRIPTION
Allows clicking outside the modal that displays the list of users who voted for a certain option, to close the modal.
https://bootboxjs.com/documentation.html#option-backdrop