### PR TITLE
BUG FIX: Race condition when saving poll

### DIFF
--- a/lib/poll.js
+++ b/lib/poll.js
@@ -32,19 +32,31 @@ const Scheduler = require('./scheduler');
 				title: val,
 			}));
 
-			// async this bitch up
+			// Save asynchronously
 			async.parallel([
-				async.apply(async.each, pollData.options, (option, next) => {
-					async.series([
-						async.apply(NodeBB.db.setObject, `poll:${pollId}:options:${option.id}`, option),
-						async.apply(NodeBB.db.setAdd, `poll:${pollId}:options`, option.id),
-					], next);
-				}),
+				async.apply(async.series, [
+					// Save poll options in parallel
+					async.apply(
+						async.parallel, 
+						pollData.options.map(
+							(option) => async.apply(NodeBB.db.setObject, `poll:${pollId}:options:${option.id}`, option)
+						),
+					),
+					// Add poll option id to option list synchronously 
+					// To avoid race condition causing duplicate error
+					async.apply(
+						async.series,
+						pollData.options.map(
+							(option) => async.apply(NodeBB.db.setAdd, `poll:${pollId}:options`, option.id)
+						),
+					),
+				]),
 				async.apply(NodeBB.db.setObject, `poll:${pollId}`, poll),
 				async.apply(NodeBB.db.setObject, `poll:${pollId}:settings`, pollData.settings),
 				async.apply(NodeBB.db.listAppend, 'polls', pollId),
 				async.apply(NodeBB.db.setObjectField, `topic:${poll.tid}`, 'pollId', pollId),
 			], (err) => {
+
 				if (err) {
 					return callback(err);
 				}


### PR DESCRIPTION
Adding the `poll option id` int to the `poll option set` asynchronously creates a race condition which results in a 'duplicate index error' (`MongoServerError: E11000 duplicate key error collection: objects index: _key_1_value_-1`). 
This is because NodeBB adds a unique key-value index.